### PR TITLE
Change schema for 'eerste inschijving' to match VrijBRP

### DIFF
--- a/ActionHandler/ZgwVrijbrpEersteInschrijvingHandler.php
+++ b/ActionHandler/ZgwVrijbrpEersteInschrijvingHandler.php
@@ -40,7 +40,7 @@ class ZgwVrijbrpEersteInschrijvingHandler implements ActionHandlerInterface
             '$schema'     => 'https://json-schema.org/draft/2020-12/schema',
             'title'       => 'VrijbrpEersteInschrijvingHandler',
             'description' => 'This handler syncs EersteInschrijving to VrijBrp',
-            'required'    => ['source', 'location', 'mapping', 'zaakEntity'],
+            'required'    => ['source', 'location', 'zaakEntity'],
             'properties'  => [
                 'source' => [
                     'type'        => 'string',
@@ -59,7 +59,7 @@ class ZgwVrijbrpEersteInschrijvingHandler implements ActionHandlerInterface
                     'type'        => 'string',
                     'description' => 'The reference of the mapping we will use before sending the data to the source',
                     'example'     => 'https://vrijbrp.nl/mapping/vrijbrp.Vrijbrp.mapping.json',
-                    'required'    => true,
+                    'required'    => false,
                     '$ref'        => 'https://commongroundgateway.nl/commongroundgateway.mapping.entity.json',
                 ],
                 'synchronizationEntity' => [

--- a/Schema/vrijbrp.document.schema.json
+++ b/Schema/vrijbrp.document.schema.json
@@ -1,0 +1,26 @@
+{
+    "$id": "https://vrijbrp.nl/schemas/vrijbrp.document.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "version": "0.1",
+    "title": "Document",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "description": "Titel van het document"
+        },
+        "filename": {
+            "type": "string",
+            "description": "Bestandsnaam"
+        },
+        "content": {
+            "type": "string",
+            "description": "Base64 gecodeerde bestandsinhoud"
+        }
+    },
+    "required": [
+        "title",
+        "filename",
+        "content"
+    ]
+}

--- a/Schema/vrijbrp.eersteInschrijving.schema.json
+++ b/Schema/vrijbrp.eersteInschrijving.schema.json
@@ -1,82 +1,102 @@
 {
     "$id": "https://vrijbrp.nl/schemas/vrijbrp.eersteInschrijving.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "version": "0.1",
+    "version": "0.2",
     "title": "EersteInschrijving",
     "type": "object",
     "properties": {
-        "sex": {
+        "referentienummer": {
+            "type": "string",
+            "description": "Referentienummer"
+        },
+        "geslacht": {
             "type": "string",
             "description": "Geslacht",
             "enum": [
-                "female",
-                "male"
+                "V",
+                "M"
             ]
         },
-        "firstnames": {
+        "voornamen": {
             "type": "string",
             "description": "Voornamen"
         },
-        "infix": {
+        "voorvoegsel": {
             "type": "string",
             "description": "Voorvoegsel/tussenvoegsel"
         },
-        "surname": {
+        "achternaam": {
             "type": "string",
             "description": "Achternaam"
         },
-        "dateOfBirth": {
+        "geboortedatum": {
             "type": "string",
             "description": "Geboortedatum"
         },
-        "birthplace": {
+        "geboorteplaats": {
             "type": "string",
             "description": "Geboorteplaats"
         },
-        "countryOfBirth": {
+        "geboorteland": {
             "type": "string",
             "description": "Geboorteland"
         },
-        "email": {
+        "land van vorig adres": {
+            "type": "string",
+            "description": "Land van vorig adres"
+        },
+        "e-mail": {
             "type": "string",
             "description": "E-mail adres"
         },
-        "phoneNumber": {
+        "telefoon": {
             "type": "string",
             "description": "Telefoonnummer"
         },
-        "postalCode": {
+        "postcode": {
             "type": "string",
             "description": "Postcode (nieuw adres)"
         },
-        "houseNumber": {
+        "huisnummer": {
             "type": "string",
             "description": "Huisnummer (nieuw adres)"
         },
-        "houseNumberAddition": {
+        "huisletter": {
             "type": "string",
-            "description": "Huisletter/huisnummertoevoeging (nieuw adres)"
+            "description": "Huisletter (nieuw adres)"
         },
-        "street": {
+        "toevoeging": {
+            "type": "string",
+            "description": "Huisnummertoevoeging (nieuw adres)"
+        },
+        "straatnaam": {
             "type": "string",
             "description": "Straatnaam (nieuw adres)"
         },
-        "city": {
+        "woonplaats": {
             "type": "string",
             "description": "Woonplaats (nieuw adres)"
+        },
+        "datum ingang bewoning": {
+            "type": "string",
+            "description": "Datum ingang bewoning"
+        },
+        "opmerkingen": {
+            "type": "string",
+            "description": "Opmerkingen bij nieuw adres)"
         }
     },
     "required": [
-        "sex",
-        "firstnames",
-        "surname",
-        "dateOfBirth",
-        "birthplace",
-        "countryOfBirth",
-        "email",
-        "postalCode",
-        "houseNumber",
-        "street",
-        "city"
+        "geslacht",
+        "voornamen",
+        "achternaam",
+        "geboortedatum",
+        "geboorteplaats",
+        "geboorteland",
+        "e-mail",
+        "postcode",
+        "huisnummer",
+        "straatnaam",
+        "woonplaats"
     ]
 }

--- a/Schema/vrijbrp.importRecord.schema.json
+++ b/Schema/vrijbrp.importRecord.schema.json
@@ -1,12 +1,18 @@
 {
     "$id": "https://vrijbrp.nl/schemas/vrijbrp.importRecord.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "version": "0.1",
+    "version": "0.2",
     "title": "ImportRecord",
     "type": "object",
     "properties": {
         "values": {
             "$ref": "https://vrijbrp.nl/schemas/vrijbrp.eersteInschrijving.schema.json"
+        },
+        "documents": {
+            "type": "array",
+            "items": {
+                "$ref": "https://vrijbrp.nl/schemas/vrijbrp.document.schema.json"
+            }
         }
     },
     "required": [

--- a/Service/EersteInschrijvingService.php
+++ b/Service/EersteInschrijvingService.php
@@ -73,9 +73,9 @@ class EersteInschrijvingService
         // $this->syncService->synchronize($synchronization, $objectArray);
 
         // Todo: temp way of doing this without updated synchronize() function...
-        if ($this->zgwToVrijbrpService->synchronizeTemp($synchronization, $objectArray, $this->configuration['location'])) {
+        if ($data = $this->zgwToVrijbrpService->synchronizeTemp($synchronization, $objectArray, $this->configuration['location'])) {
             // Return empty array on error for when we got here through a command.
-            return [];
+            return ['response' => $data];
         }
 
         return $data;

--- a/Service/ZgwToVrijbrpService.php
+++ b/Service/ZgwToVrijbrpService.php
@@ -788,7 +788,7 @@ class ZgwToVrijbrpService
                 [
                     'body'    => $objectString,
                     //'query'   => [],
-                    //'headers' => [],
+                    'headers' => ['Content-Type' => 'application/json'],
                 ]
             );
         } catch (Exception|GuzzleException $exception) {


### PR DESCRIPTION
| Q             | A|
| ------------- | ---|
| Bug fix?      | no|
| New feature?  | yes|
| BC breaks?    | yes|
| Deprecations? | no|
| Tests pass?   | n/a|
| Fixed tickets | n/a|
| License       | EUPL-1.2|
| Doc PR        | n/a|

- Change schema "eerste inschrijving" to match VrijBRP. 
- No mapping is required, so the mapping field in the handler is now optional
- VrijBRP requires HTTP header Content-Type, so the header is added